### PR TITLE
[Bug] HTML 문자 엔티티 이슈에 대응합니다 (이슈 #39)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@sentry/nextjs": "^7.13.0",
         "axios": "^0.27.2",
         "cypress-multi-reporters": "^1.6.1",
+        "html-entities": "^2.3.3",
         "next": "12.2.5",
         "react": "18.1.0",
         "react-dom": "18.1.0",
@@ -6632,6 +6633,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -18711,6 +18717,11 @@
       "requires": {
         "whatwg-encoding": "^1.0.5"
       }
+    },
+    "html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "html-escaper": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@sentry/nextjs": "^7.13.0",
     "axios": "^0.27.2",
     "cypress-multi-reporters": "^1.6.1",
+    "html-entities": "^2.3.3",
     "next": "12.2.5",
     "react": "18.1.0",
     "react-dom": "18.1.0",

--- a/src/utils/parser/question.ts
+++ b/src/utils/parser/question.ts
@@ -1,4 +1,15 @@
+import { decode } from 'html-entities';
+
 import { IAnswer, IApiQuestion, IApiQuestions } from 'src/types/quiz';
+
+/**
+ * HTML 문자 엔티티를 해석합니다.
+ * @param text 인코딩된 HTML 문자열
+ * @returns 디코드된 HTML 문자열
+ */
+const decodingHTML = (text: string) => {
+  return decode(text, { level: 'html5' });
+};
 
 /**
  * shuffleQuestion 함수
@@ -22,11 +33,11 @@ const parseQuestion = (data: IApiQuestion) => {
     category: data.category,
     type: data.type,
     difficulty: data.difficulty,
-    question: data.question,
+    question: decodingHTML(data.question),
     answers: shuffleQuestion([
-      { answer: data.correct_answer, isCorrect: true },
+      { answer: decodingHTML(data.correct_answer), isCorrect: true },
       ...data.incorrect_answers.map((answer) => {
-        return { answer, isCorrect: false };
+        return { answer: decodingHTML(answer), isCorrect: false };
       }),
     ]),
   };


### PR DESCRIPTION
# HTML 문자 엔티티 이슈에 대응합니다
## 구현
- [x] API response 값 중에서 HTML 문자 엔티티가 그대로 출력되는 이슈 처리
- [x] `html-entities` 패키지 설치 

## 이슈
- [x] 없음

## 참조
- #40
- [html-entities](https://www.npmjs.com/package/html-entities)
