### PR TITLE
[Bug] 퀴즈 하단 버튼 UI 이슈를 고칩니다 (이슈 #49)

### DIFF
--- a/src/components/question/Question.tsx
+++ b/src/components/question/Question.tsx
@@ -115,9 +115,8 @@ const Question = () => {
           className={`pl-6 pr-4 question-move-button ${!isNextQuiz && !isEndQuiz && 'invisible'}`}
           onClick={isNextQuiz ? handleClickNextMoveQuestion : handleClickShowReport}
         >
-          {`${isNextQuiz ? '다음문제' : ''}${isEndQuiz ? '결과 보기' : ''}`}
-          { isNextQuiz && (<ArrowRight />)}
-          { isEndQuiz && (<DocumentBoard />)}
+          {`${isEndQuiz ? '결과 보기' : '다음문제'}`}
+          { isEndQuiz ? (<DocumentBoard />) : (<ArrowRight />)}
         </button>
       </div>
     </>


### PR DESCRIPTION
# 퀴즈 하단 버튼 UI 이슈를 고칩니다
## 구현
- [x] 버튼 노출 조건 변경

## 이슈
- [x] 없음

## 참조
- #49
- 버튼은 다음과 같은 조건을 가짐
- 1. 다음문제
- 2. 결과 보기
- 3. (아무것도 보이지 않음)
